### PR TITLE
一ヵ月のカレンダーのPropsを変更した

### DIFF
--- a/src/Components/molecules/WeekPart.tsx
+++ b/src/Components/molecules/WeekPart.tsx
@@ -1,17 +1,17 @@
 import { HStack } from '@chakra-ui/layout'
 import { DayPart } from 'Components/atoms/DayPart'
-import { MonthSchedule } from 'Data/DummyData'
 
 type props = {
   dayList: Array<number>
+  schedule: Array<number>
 }
 
-export const WeekPart = ({ dayList }: props) => {
+export const WeekPart = ({ dayList, schedule }: props) => {
   const WeekComponent = dayList.map((element, index) => (
     <DayPart
       key={index}
       day={element}
-      rate={element !== 0 ? MonthSchedule[element - 1] : 0}
+      rate={element !== 0 ? schedule[element - 1] : 0}
       isSunday={index === 6 ? true : false}
       isSaturday={index === 0 ? true : false}
     />

--- a/src/Components/organisms/MonthCalendar.tsx
+++ b/src/Components/organisms/MonthCalendar.tsx
@@ -1,7 +1,11 @@
 import { VStack, Center, Text } from '@chakra-ui/layout'
 import { WeekPart } from 'Components/molecules/WeekPart'
 
-export const MonthCalendar = () => {
+type Props = {
+  schedule: Array<number>
+}
+
+export const MonthCalendar = ({ schedule }: Props) => {
   const date = new Date()
 
   //今月が何月か
@@ -26,7 +30,11 @@ export const MonthCalendar = () => {
 
   //一週間のコンポーネントの配列
   const MonthComponent = Array.from({ length: 5 }, (_, index) => (
-    <WeekPart key={index} dayList={dayList.slice(index * 7, index * 7 + 7)} />
+    <WeekPart
+      key={index}
+      dayList={dayList.slice(index * 7, index * 7 + 7)}
+      schedule={schedule}
+    />
   ))
 
   return (

--- a/src/Components/templates/MonthScheduleCard.tsx
+++ b/src/Components/templates/MonthScheduleCard.tsx
@@ -7,9 +7,10 @@ import { VSpacer, HSpacer } from 'Components/atoms/Spacer'
 type Props = {
   icon: string
   username: string
+  schedule: Array<number>
 }
 
-export const MonthScheduleCard = ({ icon, username }: Props) => {
+export const MonthScheduleCard = ({ icon, username, schedule }: Props) => {
   return (
     <>
       <Card
@@ -27,7 +28,7 @@ export const MonthScheduleCard = ({ icon, username }: Props) => {
             <HSpacer size={6} />
           </HStack>
           <VSpacer size={1} />
-          <MonthCalendar />
+          <MonthCalendar schedule={schedule} />
         </VStack>
       </Card>
     </>

--- a/src/pages/Components.tsx
+++ b/src/pages/Components.tsx
@@ -15,7 +15,7 @@ import { SimpleButton } from 'Components/atoms/SimpleButton'
 import { MonthCalendar } from 'Components/organisms/MonthCalendar'
 import { ScheduleCard } from 'Components/atoms/ScheduleCard'
 import { MonthScheduleCard } from 'Components/templates/MonthScheduleCard'
-import { MemberList } from 'Data/DummyData'
+import { MemberList, MonthSchedule } from 'Data/DummyData'
 
 export const Components = () => {
   const userdata = MemberList[0]
@@ -112,7 +112,7 @@ export const Components = () => {
           <Heading size="lg">MonthCalendar</Heading>
           <Card variant="filled">
             <CardBody>
-              <MonthCalendar />
+              <MonthCalendar schedule={MonthSchedule} />
             </CardBody>
           </Card>
 
@@ -121,7 +121,11 @@ export const Components = () => {
           <Heading size="lg">templates/MonthScheduleCard</Heading>
           <Card variant="filled">
             <CardBody>
-              <MonthScheduleCard icon={userdata.src} username={userdata.name} />
+              <MonthScheduleCard
+                icon={userdata.src}
+                username={userdata.name}
+                schedule={MonthSchedule}
+              />
             </CardBody>
           </Card>
 


### PR DESCRIPTION
## 🔨 変更内容

- 一ヵ月カレンダーに、空き時間の配列を外から渡して表示させるようにした
- 関連する箇所を変更した

## 📸 スクリーンショット
見た目は変化なし
![スクリーンショット 2023-05-29 112910](https://github.com/0time-engineer/front-end/assets/117695575/d1c744b2-1d91-48d3-b845-2cd8017d281f)

## 💡 レビューの観点

### PR 作成者のチェック項目

- [x] セルフレビュー
- [ ] CI/CD がすべて pass している
- [x] Reviewer の指定

## ✅ 解決するイシュー

- close #36 
