### PR TITLE
情報表示バーに一週間カレンダーを追加

### DIFF
--- a/src/Components/molecules/MySchedule.tsx
+++ b/src/Components/molecules/MySchedule.tsx
@@ -1,4 +1,7 @@
 import { Box, HStack, Image, Text, VStack } from '@chakra-ui/react'
+import { HSpacer } from 'Components/atoms/Spacer'
+
+import { WeekCalender } from 'Components/organisms/WeekCalender'
 
 type Props = {
   icon: string
@@ -6,14 +9,16 @@ type Props = {
 }
 export const MySchedule = ({ icon, username }: Props) => {
   return (
-    <>
-      <HStack>
-        <VStack>
-          <Image borderRadius="full" boxSize="20" src={icon} />
-          <Text as="b">{username}</Text>
-        </VStack>
-        <Box /*一週間カレンダー*/ />
-      </HStack>
-    </>
+    <HStack>
+      <VStack>
+        <Image borderRadius="full" boxSize="20" src={icon} />
+        <Text as="b">{username}</Text>
+      </VStack>
+
+      <Box flex="1">
+        <WeekCalender />
+      </Box>
+      <HSpacer size={1} />
+    </HStack>
   )
 }


### PR DESCRIPTION
## 🔨 変更内容

- １週間カレンダーをアイコンとユーザー名の隣に配置

## 📸 スクリーンショット
 - PC
![image](https://github.com/0time-engineer/front-end/assets/117695472/40e604f9-d056-498a-a7d2-15d98f0c7915)

 - iPhone

![image](https://github.com/0time-engineer/front-end/assets/117695472/64511ac5-28d4-4cb9-a9bf-a6ff04912370)



## 📢 この PR に含まないこと

- xxx

## 💡 レビューの観点

### PR 作成者のチェック項目

- [x] セルフレビュー
- [ ] CI/CD がすべて pass している
- [x] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー

## ✅ 解決するイシュー

- close #54 

## 🤝 関連するイシュー

- #0
