### PR TITLE
homeの調整

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,9 +1,9 @@
-import { Flex, Box } from '@chakra-ui/react'
+import { Flex, Box, Spacer } from '@chakra-ui/react'
 import { NavigationBar } from 'Components/atoms/NavigationBar'
 import { VSpacer } from 'Components/atoms/Spacer'
 import { MySchedule } from 'Components/molecules/MySchedule'
 import { ScheduleCard } from 'Components/templates/ScheduleCard'
-import { useState, useRef } from 'react'
+import { useState } from 'react'
 import { Friend } from 'Data/DummyData'
 import { MonthScheduleCard } from 'Components/templates/MonthScheduleCard'
 
@@ -18,64 +18,66 @@ export const Home = ({ icon, username }: Props) => {
     null,
   )
 
-  const monthScheduleCardRef = useRef<HTMLDivElement>(null)
-
   const handleScheduleCardClick = (index: number) => {
     setSelectedCardIndex(index === selectedCardIndex ? null : index)
   }
 
-  const handleClickInside = () => {
+  const handleOutsideClick = () => {
     setSelectedCardIndex(null)
   }
 
   return (
     <>
+      {/* 自分のスケジュールのヘッダー */}
       <VSpacer size={10} />
       <Flex
         position="fixed"
-        top={0}
+        top={10}
         left={0}
         right={0}
-        zIndex={10}
         bg="whiteAlpha.800"
         boxShadow="xl"
-        marginBottom={40}
       >
-        <MySchedule icon={icon} username={username} />
+        <Box width="100%">
+          <MySchedule icon={icon} username={username} />
+        </Box>
       </Flex>
-      <VSpacer size={24} />
+      <VSpacer size={32} />
       {Array.from({ length: num }).map((_, index) => (
         <Box key={index} position="relative">
+          {/* 友達のスケジュールカード */}
           <ScheduleCard
             icon={icon}
             username={username}
             onClick={() => handleScheduleCardClick(index)}
           />
           {selectedCardIndex === index && (
-            <Box
+            // 友達の月カレンダーの表示
+            <Flex
               position="fixed"
-              top={8}
-              left={12}
-              zIndex={20}
-              width="100%"
-              height="100%"
-              boxShadow="dark-lg"
-              borderRadius={'30px 0px 0px 30px'}
-              ref={monthScheduleCardRef}
-              onClick={handleClickInside}
+              top={10}
+              left={0}
+              right={-5}
+              bottom={0}
+              bg="whiteAlpha.800"
+              boxShadow="xl"
+              zIndex={10}
+              direction="row"
+              onClick={handleOutsideClick}
             >
+              <Spacer />
               <MonthScheduleCard
                 icon={icon}
                 username={username}
                 schedule={[1, 2, 3]}
                 onClose={() => setSelectedCardIndex(null)}
               />
-            </Box>
+            </Flex>
           )}
           <VSpacer size={4} />
         </Box>
       ))}
-      <NavigationBar type={'Home'} />
+      <NavigationBar type="Home" />
     </>
   )
 }


### PR DESCRIPTION
作り変えた

## 🔨 変更内容

- homeの画面を調整しました　
- カードが二重に表示されるのも変更しました
-自分の1週間スケジュール表示のエラーも直しました
-1か月カレンダーのカードがどのサイズでも右端に表示できるようにしました
-1か月のカレンダーのカードを消すための導線を作成しました

## 📸 スクリーンショット
PC
![image](https://github.com/0time-engineer/front-end/assets/117695498/34bc084f-c10c-4e02-ba01-c4539ed1e456)
![image](https://github.com/0time-engineer/front-end/assets/117695498/3d225af8-ce25-49c1-94ee-baf9fd4da796)

iPhone
![image](https://github.com/0time-engineer/front-end/assets/117695498/878f7d10-3220-4cfa-9c49-923cc6bb31c3)
![image](https://github.com/0time-engineer/front-end/assets/117695498/ba9769de-0df3-4ddd-84eb-ab2ffcec933f)


## 📢 この PR に含まないこと

- スワイプ表示を組んだのですが、右端であることからあってもあまり動かなかったので消しました

## 💡 レビューの観点


### PR 作成者のチェック項目

- [ ] セルフレビュー
- [ ] CI/CD がすべて pass している
- [ ] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー

## ✅ 解決するイシュー

- close #61

## 🤝 関連するイシュー

- #0
