### PR TITLE
繋ぎ合わせ：フレンドの情報を人数分表示させる

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -64,31 +64,13 @@ export const Home = ({ icon, username }: Props) => {
         )}`,
       )
       .then((response) => {
-        console.log('FriendList: ' + response.data)
+        console.log(response.data)
         setFriendList(response.data)
       })
       .catch((error) => {
         console.log(error)
       })
   }, [])
-
-  //フレンドのデータを取得
-  const [FriendData, setFriendData] = useState<any>([])
-  useEffect(() => {
-    if (FriendList !== null) {
-      FriendList.forEach((element: string) => {
-        axios
-          .get(`http://localhost:8080/user_detail?user_id=${element}`)
-          .then((response) => {
-            console.log('FriendData: ' + response.data)
-            setFriendData([...FriendData, response.data])
-          })
-          .catch((error) => {
-            console.log(error)
-          })
-      })
-    }
-  }, FriendList)
 
   return (
     <>
@@ -110,13 +92,13 @@ export const Home = ({ icon, username }: Props) => {
         </Box>
       </Flex>
       <VSpacer size={32} />
-      {Array.from({ length: FriendData ? FriendData.length : 0 }).map(
+      {Array.from({ length: FriendList ? FriendList.length : 0 }).map(
         (_, index) => (
           <Box key={index} position="relative">
             {/* 友達のスケジュールカード */}
             <ScheduleCard
-              icon={FriendData[index].picture}
-              username={FriendData[index].given_name}
+              icon={FriendList[index].icon}
+              username={FriendList[index].name}
               onClick={() => handleScheduleCardClick(index)}
             />
             {selectedCardIndex === index && (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -53,23 +53,42 @@ export const Home = ({ icon, username }: Props) => {
         console.log(error)
       })
   }, [])
-  //フレンドのデータを取得
-  const [FriendData, setFriendData] = useState<any>(null)
+
+  //フレンドリストを取得
+  const [FriendList, setFriendList] = useState<any>(null)
   useEffect(() => {
     axios
       .get(
-        `http://localhost:8080/user_detail?friend_list=${localStorage.getItem(
-          'my_mail',
+        `http://localhost:8080/friend_list?my_mail=${localStorage.getItem(
+          'user_id',
         )}`,
       )
       .then((response) => {
-        console.log(response.data)
-        setFriendData(response.data)
+        console.log('FriendList: ' + response.data)
+        setFriendList(response.data)
       })
       .catch((error) => {
         console.log(error)
       })
   }, [])
+
+  //フレンドのデータを取得
+  const [FriendData, setFriendData] = useState<any>([])
+  useEffect(() => {
+    if (FriendList !== null) {
+      FriendList.forEach((element: string) => {
+        axios
+          .get(`http://localhost:8080/user_detail?user_id=${element}`)
+          .then((response) => {
+            console.log('FriendData: ' + response.data)
+            setFriendData([...FriendData, response.data])
+          })
+          .catch((error) => {
+            console.log(error)
+          })
+      })
+    }
+  }, FriendList)
 
   return (
     <>
@@ -96,8 +115,8 @@ export const Home = ({ icon, username }: Props) => {
           <Box key={index} position="relative">
             {/* 友達のスケジュールカード */}
             <ScheduleCard
-              icon={icon}
-              username={username}
+              icon={FriendData[index].picture}
+              username={FriendData[index].given_name}
               onClick={() => handleScheduleCardClick(index)}
             />
             {selectedCardIndex === index && (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,7 +4,6 @@ import { VSpacer } from 'Components/atoms/Spacer'
 import { MySchedule } from 'Components/molecules/MySchedule'
 import { ScheduleCard } from 'Components/templates/ScheduleCard'
 import { useState, useEffect } from 'react'
-import { Friend } from 'Data/DummyData'
 import { MonthScheduleCard } from 'Components/templates/MonthScheduleCard'
 import { useLocation } from 'react-router'
 import axios from 'axios'
@@ -25,7 +24,6 @@ export const Home = ({ icon, username }: Props) => {
     }
   }, [])
 
-  const num = Friend
   const [selectedCardIndex, setSelectedCardIndex] = useState<number | null>(
     null,
   )
@@ -55,6 +53,23 @@ export const Home = ({ icon, username }: Props) => {
         console.log(error)
       })
   }, [])
+  //フレンドのデータを取得
+  const [FriendData, setFriendData] = useState<any>(null)
+  useEffect(() => {
+    axios
+      .get(
+        `http://localhost:8080/user_detail?friend_list=${localStorage.getItem(
+          'my_mail',
+        )}`,
+      )
+      .then((response) => {
+        console.log(response.data)
+        setFriendData(response.data)
+      })
+      .catch((error) => {
+        console.log(error)
+      })
+  }, [])
 
   return (
     <>
@@ -76,40 +91,42 @@ export const Home = ({ icon, username }: Props) => {
         </Box>
       </Flex>
       <VSpacer size={32} />
-      {Array.from({ length: num }).map((_, index) => (
-        <Box key={index} position="relative">
-          {/* 友達のスケジュールカード */}
-          <ScheduleCard
-            icon={icon}
-            username={username}
-            onClick={() => handleScheduleCardClick(index)}
-          />
-          {selectedCardIndex === index && (
-            // 友達の月カレンダーの表示
-            <Flex
-              position="fixed"
-              top={10}
-              left={0}
-              right={-5}
-              bottom={0}
-              bg="whiteAlpha.800"
-              boxShadow="xl"
-              zIndex={10}
-              direction="row"
-              onClick={handleOutsideClick}
-            >
-              <Spacer />
-              <MonthScheduleCard
-                icon={icon}
-                username={username}
-                schedule={[1, 2, 3]}
-                onClose={() => setSelectedCardIndex(null)}
-              />
-            </Flex>
-          )}
-          <VSpacer size={4} />
-        </Box>
-      ))}
+      {Array.from({ length: FriendData ? FriendData.length : 0 }).map(
+        (_, index) => (
+          <Box key={index} position="relative">
+            {/* 友達のスケジュールカード */}
+            <ScheduleCard
+              icon={icon}
+              username={username}
+              onClick={() => handleScheduleCardClick(index)}
+            />
+            {selectedCardIndex === index && (
+              // 友達の月カレンダーの表示
+              <Flex
+                position="fixed"
+                top={10}
+                left={0}
+                right={-5}
+                bottom={0}
+                bg="whiteAlpha.800"
+                boxShadow="xl"
+                zIndex={10}
+                direction="row"
+                onClick={handleOutsideClick}
+              >
+                <Spacer />
+                <MonthScheduleCard
+                  icon={icon}
+                  username={username}
+                  schedule={[1, 2, 3]}
+                  onClose={() => setSelectedCardIndex(null)}
+                />
+              </Flex>
+            )}
+            <VSpacer size={4} />
+          </Box>
+        ),
+      )}
       <NavigationBar type="Home" />
     </>
   )


### PR DESCRIPTION
## 🔨 変更内容

- friend_listの配列の長さ分繰り返し表示させた

## 📸 スクリーンショット

![](https://cdn.discordapp.com/attachments/1108601614245314732/1113752021590343701/image.png)


## 📢 この PR に含まないこと

- フレンドのアイコン＆ユーザー名表示
- 一週間カレンダーの表示

## 💡 レビューの観点
friend_listが空だと思われるので誰も表示されません
追加してもらった後に確認します。

### PR 作成者のチェック項目

- [x] セルフレビュー
- [ ] CI/CD がすべて pass している
- [x] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー

## ✅ 解決するイシュー

- close #0

## 🤝 関連するイシュー

- #59 
