### PR TITLE
一ヵ月カレンダーの仕様変更

### DIFF
--- a/src/Components/atoms/DayPart.tsx
+++ b/src/Components/atoms/DayPart.tsx
@@ -6,6 +6,7 @@ type props = {
   isSunday: boolean
   isSaturday: boolean
   isToday: boolean
+  isFinished: boolean
 }
 
 export const DayPart = ({
@@ -14,8 +15,8 @@ export const DayPart = ({
   isSunday,
   isSaturday,
   isToday,
+  isFinished,
 }: props) => {
-  console.log(rate)
   //一日の空き具合を表す色（空き時間が多いほど濃い色で塗りつぶす）
   const color = ['#FFFFFF', '#D8F1FF', '#A6DFFF']
   //色を切り替える割合
@@ -50,7 +51,7 @@ export const DayPart = ({
             : ''
         }
       >
-        {day > 0 ? day : ''}
+        {day}
       </Circle>
     )
   }
@@ -60,7 +61,7 @@ export const DayPart = ({
       <VStack
         w="35px"
         h="95px"
-        bg={day > 0 ? bg : '#DDDDDD'}
+        bg={isFinished ? '#DDDDDD' : bg}
         color={isSunday ? '#FF2B2B' : isSaturday ? '2B80FF' : ''}
       >
         <DateComponent />

--- a/src/Components/atoms/DayPart.tsx
+++ b/src/Components/atoms/DayPart.tsx
@@ -5,12 +5,17 @@ type props = {
   rate: number
   isSunday: boolean
   isSaturday: boolean
+  isToday: boolean
 }
 
-export const DayPart = ({ day, rate, isSunday, isSaturday }: props) => {
-  const date = new Date()
-  const today = date.getDate()
-
+export const DayPart = ({
+  day,
+  rate,
+  isSunday,
+  isSaturday,
+  isToday,
+}: props) => {
+  console.log(rate)
   //一日の空き具合を表す色（空き時間が多いほど濃い色で塗りつぶす）
   const color = ['#FFFFFF', '#D8F1FF', '#A6DFFF']
   //色を切り替える割合
@@ -32,11 +37,11 @@ export const DayPart = ({ day, rate, isSunday, isSaturday }: props) => {
       <Circle
         size="30px"
         margin="2px"
-        bg={day === today ? '#707070' : ''}
+        bg={isToday ? '#707070' : ''}
         fontSize="15px"
         fontWeight="500"
         color={
-          day === today
+          isToday
             ? '#FFFFFF'
             : isSunday
             ? '#FF2B2B'
@@ -45,7 +50,7 @@ export const DayPart = ({ day, rate, isSunday, isSaturday }: props) => {
             : ''
         }
       >
-        {day !== 0 ? day : ''}
+        {day > 0 ? day : ''}
       </Circle>
     )
   }
@@ -55,7 +60,7 @@ export const DayPart = ({ day, rate, isSunday, isSaturday }: props) => {
       <VStack
         w="35px"
         h="95px"
-        bg={day !== 0 ? bg : '#DDDDDD'}
+        bg={day > 0 ? bg : '#DDDDDD'}
         color={isSunday ? '#FF2B2B' : isSaturday ? '2B80FF' : ''}
       >
         <DateComponent />

--- a/src/Components/molecules/WeekPart.tsx
+++ b/src/Components/molecules/WeekPart.tsx
@@ -2,18 +2,23 @@ import { HStack } from '@chakra-ui/layout'
 import { DayPart } from 'Components/atoms/DayPart'
 
 type props = {
+  row: number
   dayList: Array<number>
   scheduleList: Array<number>
 }
 
-export const WeekPart = ({ dayList, scheduleList }: props) => {
+const date = new Date()
+const today = date.getDate()
+
+export const WeekPart = ({ row, dayList, scheduleList }: props) => {
   const WeekComponent = dayList.map((element, index) => (
     <DayPart
       key={index}
       day={element}
-      rate={element !== 0 ? scheduleList[element - 1] : 0}
+      rate={scheduleList[index]}
       isSunday={index === 6 ? true : false}
       isSaturday={index === 0 ? true : false}
+      isToday={row === 0 && element === today ? true : false}
     />
   ))
 

--- a/src/Components/molecules/WeekPart.tsx
+++ b/src/Components/molecules/WeekPart.tsx
@@ -7,10 +7,17 @@ type props = {
   scheduleList: Array<number>
 }
 
-const date = new Date()
-const today = date.getDate()
-
 export const WeekPart = ({ row, dayList, scheduleList }: props) => {
+  const date = new Date()
+  const today = date.getDate()
+
+  let WeekFromNow = new Array<number>()
+  if (row === 0) {
+    for (let i = 0; i < 7; i++) {
+      WeekFromNow.push(date.getDate())
+      date.setDate(date.getDate() + 1)
+    }
+  }
   const WeekComponent = dayList.map((element, index) => (
     <DayPart
       key={index}
@@ -19,6 +26,7 @@ export const WeekPart = ({ row, dayList, scheduleList }: props) => {
       isSunday={index === 6 ? true : false}
       isSaturday={index === 0 ? true : false}
       isToday={row === 0 && element === today ? true : false}
+      isFinished={row === 0 && !WeekFromNow.includes(element) ? true : false}
     />
   ))
 

--- a/src/Components/molecules/WeekPart.tsx
+++ b/src/Components/molecules/WeekPart.tsx
@@ -3,15 +3,15 @@ import { DayPart } from 'Components/atoms/DayPart'
 
 type props = {
   dayList: Array<number>
-  schedule: Array<number>
+  scheduleList: Array<number>
 }
 
-export const WeekPart = ({ dayList, schedule }: props) => {
+export const WeekPart = ({ dayList, scheduleList }: props) => {
   const WeekComponent = dayList.map((element, index) => (
     <DayPart
       key={index}
       day={element}
-      rate={element !== 0 ? schedule[element - 1] : 0}
+      rate={element !== 0 ? scheduleList[element - 1] : 0}
       isSunday={index === 6 ? true : false}
       isSaturday={index === 0 ? true : false}
     />

--- a/src/Components/organisms/MonthCalendar.tsx
+++ b/src/Components/organisms/MonthCalendar.tsx
@@ -9,6 +9,12 @@ type Props = {
 export const MonthCalendar = ({ schedule }: Props) => {
   const date = new Date()
 
+  //今日が何日か
+  const today = date.getDate()
+
+  //今日が何曜日か
+  const dayOfWeek = date.getDay()
+
   //今月が何月か
   const thisMonth = date.getMonth() + 1
 
@@ -17,24 +23,36 @@ export const MonthCalendar = ({ schedule }: Props) => {
   date.setDate(0)
   const daysInMonth = date.getDate()
 
-  //今月の１日は何曜日か
-  date.setDate(1)
-  const dayOfWeek = date.getDay()
+  //翌月が何日まであるか
+  date.setMonth(thisMonth)
+  const daysInNextMonth = date.getDate()
 
   //WeekPartに渡す配列
   const firstBlank = Array(dayOfWeek).fill(0)
-  const lastBlank = Array(35 - (dayOfWeek + daysInMonth)).fill(0)
+  // const lastBlank = Array(35 - (dayOfWeek + daysInMonth)).fill(0)
 
-  const dayList = Array.from({ length: daysInMonth }, (_, index) => index + 1)
+  const dayList = Array.from(
+    { length: daysInMonth - today },
+    (_, index) => index + today,
+  )
+  const nextDayList = Array.from(
+    { length: daysInNextMonth - dayList.length },
+    (_, index) => index + 1,
+  )
+
+  //日付の配列の処理
   dayList.unshift(...firstBlank)
-  dayList.push(...lastBlank)
+  dayList.push(...nextDayList)
+
+  //スケジュールの配列の処理
+  schedule.unshift(...firstBlank)
 
   //一週間のコンポーネントの配列
   const MonthComponent = Array.from({ length: 5 }, (_, index) => (
     <WeekPart
       key={index}
       dayList={dayList.slice(index * 7, index * 7 + 7)}
-      schedule={schedule}
+      scheduleList={schedule.slice(index * 7, index * 7 + 7)}
     />
   ))
 

--- a/src/Components/organisms/MonthCalendar.tsx
+++ b/src/Components/organisms/MonthCalendar.tsx
@@ -7,6 +7,7 @@ type Props = {
 }
 
 export const MonthCalendar = ({ schedule }: Props) => {
+  const copiedSchedule = schedule.slice()
   const date = new Date()
 
   //今日が何日か
@@ -16,52 +17,58 @@ export const MonthCalendar = ({ schedule }: Props) => {
   const dayOfWeek = date.getDay()
 
   //今月が何月か
-  const thisMonth = date.getMonth() + 1
+  const thisMonth = date.getMonth()
 
-  //今月が何日まであるか
-  date.setMonth(thisMonth)
+  //今月の日数
+  date.setMonth(thisMonth + 1)
   date.setDate(0)
   const daysInMonth = date.getDate()
 
-  //翌月が何日まであるか
-  date.setMonth(thisMonth)
+  //翌月の日数
+  date.setMonth(thisMonth + 2)
+  date.setDate(0)
   const daysInNextMonth = date.getDate()
 
   //WeekPartに渡す配列
   const firstBlank = Array(dayOfWeek).fill(0)
-  // const lastBlank = Array(35 - (dayOfWeek + daysInMonth)).fill(0)
 
+  //日付の配列の処理
   const dayList = Array.from(
-    { length: daysInMonth - today },
+    { length: daysInMonth - today + 1 },
     (_, index) => index + today,
   )
   const nextDayList = Array.from(
-    { length: daysInNextMonth - dayList.length },
+    { length: daysInNextMonth },
     (_, index) => index + 1,
   )
-
-  //日付の配列の処理
   dayList.unshift(...firstBlank)
   dayList.push(...nextDayList)
+  if (35 - dayList.length > 0) {
+    const lastBlank = Array(35 - dayList.length)
+    dayList.push(...lastBlank)
+  }
 
   //スケジュールの配列の処理
-  schedule.unshift(...firstBlank)
+  copiedSchedule.unshift(...firstBlank)
+  if (35 - copiedSchedule.length > 0) {
+    const lastBlank = Array(35 - copiedSchedule.length)
+    dayList.push(...lastBlank)
+  }
 
   //一週間のコンポーネントの配列
   const MonthComponent = Array.from({ length: 5 }, (_, index) => (
     <WeekPart
       key={index}
-      dayList={dayList.slice(index * 7, index * 7 + 7)}
-      scheduleList={schedule.slice(index * 7, index * 7 + 7)}
+      dayList={dayList.slice(index * 7, (index + 1) * 7)}
+      scheduleList={copiedSchedule.slice(index * 7, (index + 1) * 7)}
+      row={index}
     />
   ))
 
   return (
     <>
       <Container maxW="md">
-        <Text fontSize="20px" fontWeight="bold" textAlign="right">
-          {thisMonth}月
-        </Text>
+        <Text fontSize="20px" fontWeight="bold" textAlign="right"></Text>
         <Center bg="whitesmoke" right={0}>
           <VStack spacing="1px">{MonthComponent}</VStack>
         </Center>

--- a/src/Components/organisms/MonthCalendar.tsx
+++ b/src/Components/organisms/MonthCalendar.tsx
@@ -16,39 +16,16 @@ export const MonthCalendar = ({ schedule }: Props) => {
   //今日が何曜日か
   const dayOfWeek = date.getDay()
 
-  //今月が何月か
-  const thisMonth = date.getMonth()
-
-  //今月の日数
-  date.setMonth(thisMonth + 1)
-  date.setDate(0)
-  const daysInMonth = date.getDate()
-
-  //翌月の日数
-  date.setMonth(thisMonth + 2)
-  date.setDate(0)
-  const daysInNextMonth = date.getDate()
-
-  //WeekPartに渡す配列
-  const firstBlank = Array(dayOfWeek).fill(0)
-
   //日付の配列の処理
-  const dayList = Array.from(
-    { length: daysInMonth - today + 1 },
-    (_, index) => index + today,
-  )
-  const nextDayList = Array.from(
-    { length: daysInNextMonth },
-    (_, index) => index + 1,
-  )
-  dayList.unshift(...firstBlank)
-  dayList.push(...nextDayList)
-  if (35 - dayList.length > 0) {
-    const lastBlank = Array(35 - dayList.length)
-    dayList.push(...lastBlank)
+  date.setDate(today - dayOfWeek)
+  let dayList = new Array<number>()
+  for (let i = 0; i < 35; i++) {
+    dayList.push(date.getDate())
+    date.setDate(date.getDate() + 1)
   }
 
   //スケジュールの配列の処理
+  const firstBlank = Array(dayOfWeek).fill(0)
   copiedSchedule.unshift(...firstBlank)
   if (35 - copiedSchedule.length > 0) {
     const lastBlank = Array(35 - copiedSchedule.length)


### PR DESCRIPTION
## 🔨 変更内容

- 今日以降のスケジュールを表示するように変更した

## 📸 スクリーンショット
![スクリーンショット 2023-06-01 200219](https://github.com/0time-engineer/front-end/assets/117695575/25bf9f39-5b30-446a-883a-620c934e81f1)

## 📢 この PR に含まないこと

- 「今日から31日分表示」と言われていたけど、今日の曜日によっては29日分の表示になることがある
（今日が金曜日の場合、今日+次の4週間分の表示になる）

## 💡 レビューの観点

### PR 作成者のチェック項目

- [ ] セルフレビュー
- [ ] CI/CD がすべて pass している
- [ ] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- パーセンテージで変更する色の指定って、外から指定できた方が良いですか？

## ✅ 解決するイシュー

- close #71

## 🤝 関連するイシュー

- #0
