### PR TITLE
day表示カードの大枠

### DIFF
--- a/src/Components/templates/DayScheduleCard.tsx
+++ b/src/Components/templates/DayScheduleCard.tsx
@@ -1,0 +1,36 @@
+import { Card, Container } from '@chakra-ui/react'
+import { HStack, VStack, Text } from '@chakra-ui/react'
+import { VSpacer } from 'Components/atoms/Spacer'
+
+type Props = {
+  celectday: string
+  celectfriend: string
+}
+
+export const DayScheduleCard = ({ celectday, celectfriend }: Props) => {
+  return (
+    <>
+      <Container maxW="sm">
+        <Card
+          maxH="8xl"
+          right={0}
+          boxShadow="2xl"
+          borderRadius={'30px 0px 0px 30px'}
+        >
+          <VStack>
+            <VSpacer size={2} />
+            <HStack>
+              {/* TODO:1日のスケジュール表示によって変更する・アイコン必要かどうか全体のレイアウト見て考える */}
+              {/* <Image borderRadius="full" boxSize="28" src={icon} />
+              dayは書いておかないと、エラーが出るので仮置きです*/}
+              <Text fontSize="20px">
+                {celectfriend}さんの{celectday}日の予定
+              </Text>
+            </HStack>
+            {/*1日スケジュール表示を入れる */}
+          </VStack>
+        </Card>
+      </Container>
+    </>
+  )
+}

--- a/src/pages/Components.tsx
+++ b/src/pages/Components.tsx
@@ -23,6 +23,7 @@ import { FilterButton } from 'Components/atoms/FilterButton'
 import { useState } from 'react'
 import { OneDayTimer } from 'Components/atoms/OneDayTimer'
 import { DayChangeButton } from 'Components/atoms/DayChangeButton'
+import { DayScheduleCard } from 'Components/templates/DayScheduleCard'
 
 export const Components = () => {
   const userdata = MemberList[0]
@@ -220,6 +221,15 @@ export const Components = () => {
           <Card variant="filled">
             <CardBody>
               <DayChangeButton day={'3'} />
+            </CardBody>
+          </Card>
+
+          {/* DayScheduleCard */}
+          <VSpacer size={8} />
+          <Heading size="lg">atomos/DayScheduleCard</Heading>
+          <Card variant="filled">
+            <CardBody>
+              <DayScheduleCard celectday={'3'} celectfriend={''} />
             </CardBody>
           </Card>
 


### PR DESCRIPTION
## 🔨 変更内容

- day表示用のカード作成

## 📸 スクリーンショット
![image](https://github.com/0time-engineer/front-end/assets/117695498/8778eac8-4610-43d9-b0b9-066ccf5ac199)
この中に、別コンポーネントがのる
## 📢 この PR に含まないこと

- カードを以外の範囲クリックしたら消える作り
- 値の受け渡しをcelectday、celectfriendのみ
-text内容を適当に表示(値全て別コンポーネントに)

## 💡 レビューの観点

### PR 作成者のチェック項目

- [ ] セルフレビュー
- [ ] CI/CD がすべて pass している
- [ ] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー

## ✅ 解決するイシュー

- close #86 

## 🤝 関連するイシュー

- #0
